### PR TITLE
Remove Snyk duplication from the companies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ A curated list of awesome Open Source Software made in Israel, and by Israelis.
 * [Amplication](https://github.com/amplication)
 * [Teambit](https://github.com/teambit)
 * [Novu](https://github.com/novuhq)  
-* [Snyk](https://github.com/snyk/)  
 * [Armo](https://github.com/armosec)  
 * [Ballerine](https://github.com/ballerine-io)
 * [Overwolf](https://github.com/overwolf)


### PR DESCRIPTION
Ir appears twice under this list.
Reordering the list alphabetically may help in avoiding such cases.