### PR TITLE
Add Noam Brand to Individuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ ic research to an artifact that engineers can deploy easily. ![GitHub last commi
 * [Natan Yellin](https://natanyellin.com/open-source/)
 * [Netanel Basal](https://github.com/NetanelBasal)
 * [Nitzan Tomer](https://github.com/nitzantomer)
-* [Noam Brand](https://github.com/noambrand)
+* [Noam Brand](https://github.com/noambrand) ![GitHub followers](https://img.shields.io/github/followers/noambrand?style=flat-square) ![GitHub stars](https://img.shields.io/github/stars/noambrand?style=flat-square&label=stars&affiliations=OWNER)
 * [Omer Zak](https://zak.co.il/)
 * [Or Weis](https://github.com/orweis)
 * [Orel Balilti](https://github.com/o-b-one)

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ ic research to an artifact that engineers can deploy easily. ![GitHub last commi
 * [Natan Yellin](https://natanyellin.com/open-source/)
 * [Netanel Basal](https://github.com/NetanelBasal)
 * [Nitzan Tomer](https://github.com/nitzantomer)
-* [Noam Brand](https://github.com/noambrand) ![GitHub followers](https://img.shields.io/github/followers/noambrand?style=flat-square) ![GitHub stars](https://img.shields.io/github/stars/noambrand?style=flat-square&label=stars&affiliations=OWNER)
+* [Noam Brand](https://github.com/noambrand)
 * [Omer Zak](https://zak.co.il/)
 * [Or Weis](https://github.com/orweis)
 * [Orel Balilti](https://github.com/o-b-one)

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ ic research to an artifact that engineers can deploy easily. ![GitHub last commi
 * [Natan Yellin](https://natanyellin.com/open-source/)
 * [Netanel Basal](https://github.com/NetanelBasal)
 * [Nitzan Tomer](https://github.com/nitzantomer)
+* [Noam Brand](https://github.com/noambrand)
 * [Omer Zak](https://zak.co.il/)
 * [Or Weis](https://github.com/orweis)
 * [Orel Balilti](https://github.com/o-b-one)


### PR DESCRIPTION
Per your suggestion on #283 — listing the developer instead of the individual repos.

Adds [Noam Brand](https://github.com/noambrand) to the `## Individuals` section, alphabetically between Nitzan Tomer and Omer Zak. He maintains [kivun-terminal](https://github.com/noambrand/kivun-terminal) and [kivun-terminal-wsl](https://github.com/noambrand/kivun-terminal-wsl) (Claude Code installers with RTL + LTR support).

## Checklist
- [x] Read and adhere to the Code of Conduct
- [x] Right category (Individuals)
- [x] Alphabetical order preserved
- [x] Single line per item
- [x] No duplicates (verified via README search)